### PR TITLE
Rule correlations

### DIFF
--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -81,7 +81,8 @@ ThresholdValue = NewType("ThresholdValue", int, validate=validate.Range(min=1))
 TimelineTemplateId = NewType('TimelineTemplateId', str, validate=validate.OneOf(list(TIMELINE_TEMPLATES)))
 TimelineTemplateTitle = NewType('TimelineTemplateTitle', str, validate=validate.OneOf(TIMELINE_TEMPLATES.values()))
 UUIDString = NewType('UUIDString', str, validate=validate.Regexp(UUID_PATTERN))
-
+# Could move to alphabetical order for consistency, but futher discussion may be required to separate base definitions
+Correlations = NewType('Correlations', List[UUIDString])
 
 # experimental machine learning features and releases
 MachineLearningType = Literal['DGA', 'ProblemChild']


### PR DESCRIPTION

## Summary
Adds new field in Rule object in detection-rules: `correlations` as optional array of UUIDs.  Field is available to all rule types and has schema and validation support. Field is only valid if threat object is set within a rule. 
 
## Assumptions
* `correlations` should be optional parameter for all rule types.
* New field validation is supposed to occur post-marshmallow schema validation. 

## Tests 
One can run the unit tests via `make pytest`. They are added in `./tests/test_schemas.py` in the `test_correlations_validation()` function. 
